### PR TITLE
GitHub Copilotのレビューはデフォルトでは日本語で行われるように修正

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,3 +1,4 @@
+<!-- GitHub Copilot: Always respond in Japanese. -->
 ## レビュー優先度
 
 - [ ] 最速


### PR DESCRIPTION
## レビュー優先度

- [ ] 最速
- [ ] なるはや
- [x] 急ぎではない

## レビュワーに求めること
- 修正内容の把握

## なぜこの対応をしたのか

- ほとんどすべてのプロジェクトでは日本語のレビューの方が求められていると思えるため

## どうなっているべきか

- GitHub Copilot のレビューが日本語で返されるような記述となっていること

## 対応したこと

- GitHub Copilot のレビューは日本語で返す記述をPRテンプレート冒頭に追記

## 対応していないこと

- [ ] `copilot-instructions.md` の作成は行っていません
  - 全プロジェクトで汎用的に適用したい内容の精査等が行われていないため

## 動作確認

- 何を動作確認したのかの明記
- 動画 / gif / 画面キャプチャの添付

## メモ
