### PR TITLE
Copilotの日本語回答指示は copilot-instructions.md 側で行うように修正

### DIFF
--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -1,0 +1,8 @@
+# GitHub Copilotへの指示
+
+すべてのレビューコメント、提案、プルリクエストの要約は、必ず日本語で記述してください。
+
+---
+# Instructions for GitHub Copilot
+
+All review comments, suggestions, and pull request summaries must be written in Japanese.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,4 +1,3 @@
-<!-- GitHub Copilot: Always respond in Japanese. -->
 ## レビュー優先度
 
 - [ ] 最速


### PR DESCRIPTION
<!-- GitHub Copilot: Always respond in Japanese. -->
## レビュー優先度

- [ ] 最速
- [x] なるはや
- [ ] 急ぎではない

## レビュワーに求めること
対応内容の把握

## なぜこの対応をしたのか

- 以下のPRで日本語レビューの指定をPRテンプレート内で行ったが、うまく対応できないケースがあったため公式の方法に倣って `.github/copilot-instructions.md` 内で指示を記述するように変更
  -  #2
- 公式の手法参考: https://docs.github.com/ja/copilot/how-tos/use-copilot-agents/request-a-code-review/use-code-review

## どうなっているべきか

- `.github/copilot-instructions.md` 内で日本語レビューの指示が記載されている

## 対応したこと

- [x] `.github/copilot-instructions.md` に日本語レビューの指示を記載
- [x] PRテンプレート側の指示は撤去 

指示内容はGeminiに検討してもらった。

指示内容のキャプチャ:
<img width="817" height="973" alt="SCR-20250910-rufw" src="https://github.com/user-attachments/assets/635a13aa-2740-4347-9b1a-a84b831c3483" />

## 対応していないこと

- [ ] 変更1
  - なぜやっていないのか理由
  - いつやるのか / できないなら issue or ClickUp に登録したか

## 動作確認

- 何を動作確認したのかの明記
- 動画 / gif / 画面キャプチャの添付

## メモ
